### PR TITLE
Add support of 128 bit trace ids

### DIFF
--- a/src/otter_lib_zipkin_thrift.erl
+++ b/src/otter_lib_zipkin_thrift.erl
@@ -67,8 +67,10 @@ span_to_struct(#span{
     timestamp = Timestamp,
     duration = Duration
 }, ExtraTags, ServiceDefaults) ->
+    TraceIdHigh = TraceId bsr 64,
+    TraceIdLow = TraceId rem (1 bsl 64),
     [
-        {1, i64, TraceId},
+        {1, i64, TraceIdLow},
         {3, string, otter_lib:to_bin(Name)},
         {4, i64, Id}
     ] ++
@@ -89,7 +91,13 @@ span_to_struct(#span{
         }},
         {10, i64, Timestamp},
         {11, i64, Duration}
-    ].
+    ] ++
+    case TraceIdHigh of
+        0 ->
+            [];
+        TraceIdHigh ->
+            [{12, i64, TraceIdHigh}]
+    end.
 
 log_to_annotation({Timestamp, Text}, _ServiceDefaults) ->
     [


### PR DESCRIPTION
According to [b3-propagation spec](https://github.com/openzipkin/b3-propagation/blob/master/README.md#traceid-1) trace ID might be a 128-bit integer. When we use otter to create spans with trace IDs from external systems they are truncated to 64 bits during encoding to thrift. But zipkin's thrift API [supports 128 bit trace IDs](https://github.com/openzipkin/zipkin-api/blob/master/thrift/zipkinCore.thrift#L506). 

This PR adds sending of high bits of 128-bit trace IDs to zipkin.